### PR TITLE
feat(viz): add FiftyOne backend to lerobot-dataset-viz

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -180,7 +180,8 @@ LeRobot provides **feature-scoped extras** that map to common workflows. If you 
 | `dataset`  | `datasets`, `av`, `torchcodec`, `jsonlines` | Loading & creating datasets         |
 | `training` | `dataset` + `accelerate`, `wandb`           | Training policies                   |
 | `hardware` | `pynput`, `pyserial`, `deepdiff`            | Connecting to real robots           |
-| `viz`      | `rerun-sdk`                                 | Visualization during recording/eval |
+| `viz`      | `rerun-sdk`, `foxglove-sdk`                 | Visualization during recording/eval |
+| `fiftyone` | `fiftyone`                                  | Browse datasets in the FiftyOne App |
 
 **Composite Extras** combine feature extras for common CLI scripts:
 

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -319,6 +319,15 @@ Once executed, the tool opens `rerun.io` and displays the camera streams, robot 
 
 To use [Foxglove](https://foxglove.dev) instead of Rerun, install the extra add `--display-mode foxglove`. This starts a WebSocket server (connect the Foxglove app to `ws://127.0.0.1:8765`) that serves the episode as a seekable timeline you can play/pause and scrub.
 
+To use [FiftyOne](https://docs.voxel51.com) instead, install its extra (`pip install 'lerobot[fiftyone]'`) and add `--display-mode fiftyone`. FiftyOne imports the episode directly from the on-disk dataset (no re-encoding) and opens the FiftyOne App in your browser at `http://localhost:5151`. Each episode shows one Image tile per camera, a **State & Action** tile with the per-dimension curves synchronized to the video, per-dimension **Plot** tiles, plus **Streams** and **Statistics** tabs. Add `--all-episodes` to browse the whole dataset, or `--remote` on a headless machine (then forward the port with `ssh -N -L 5151:127.0.0.1:5151 user@host`). The FiftyOne dataset is kept when you exit, so any tags or saved views you add in the App survive and you can reopen it with `fiftyone app launch <name>`; pass `--no-persistent` for a throwaway session.
+
+```bash
+lerobot-dataset-viz \
+    --repo-id lerobot/pusht \
+    --episode-index 0 \
+    --display-mode fiftyone
+```
+
 For advanced usage—including visualizing datasets stored on a remote server—run:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ viz = [
     "rerun-sdk>=0.24.0,<0.34.0",
     "foxglove-sdk>=0.25.1,<0.26.0",
 ]
+# Optional FiftyOne App backend for `lerobot-dataset-viz --display-mode fiftyone`. Kept out of `viz`
+# because fiftyone ships its own database binary (~200 MB); install on demand with `lerobot[fiftyone]`.
+fiftyone = ["fiftyone>=1.23.0"]
 # ── User-facing composite extras (map to CLI scripts) ─────
 # lerobot-record, lerobot-replay, lerobot-calibrate, lerobot-teleoperate, etc.
 core_scripts = ["lerobot[dataset]", "lerobot[hardware]", "lerobot[viz]"]
@@ -508,6 +511,9 @@ default.extend-ignore-identifiers-re = [
     "OT_VALUE",
     "VanderBilt",
     "seperated_timestep",
+    "^fot?$",       # FiftyOne import aliases: `import fiftyone as fo`, `import fiftyone.types as fot`
+    "fo_dataset",
+    "fake_fo",
 ]
 
 # Docstring coverage gate. `fail-under` is a RATCHET, not a target: it is set just below the currently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ viz = [
 ]
 # Optional FiftyOne App backend for `lerobot-dataset-viz --display-mode fiftyone`. Kept out of `viz`
 # because fiftyone ships its own database binary (~200 MB); install on demand with `lerobot[fiftyone]`.
-fiftyone = ["fiftyone>=1.23.0"]
+fiftyone = ["fiftyone>=1.23.0,<2.0.0"]
 # ── User-facing composite extras (map to CLI scripts) ─────
 # lerobot-record, lerobot-replay, lerobot-calibrate, lerobot-teleoperate, etc.
 core_scripts = ["lerobot[dataset]", "lerobot[hardware]", "lerobot[viz]"]
@@ -304,6 +304,7 @@ all = [
     "lerobot[training]",
     "lerobot[hardware]",
     "lerobot[viz]",
+    "lerobot[fiftyone]",
     # NOTE(resolver hint): scipy is pulled in transitively via lerobot[scipy-dep] through
     # multiple extras (aloha, metaworld, pi, wallx, phone). Listing it explicitly
     # helps pip's resolver converge by constraining scipy early, before it encounters

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -174,7 +174,7 @@ def build_blueprint_from_dataset(dataset: LeRobotDataset):
 
 def visualize_dataset(
     dataset: LeRobotDataset,
-    episode_index: int | None,
+    episode_index: int,
     batch_size: int = 32,
     num_workers: int = 0,
     mode: str = "local",
@@ -186,34 +186,8 @@ def visualize_dataset(
     display_mode: str = "rerun",
     host: str | None = None,
     autoplay: bool = True,
-    remote: bool = False,
-    all_episodes: bool = False,
-    persistent: bool = True,
-    fo_dataset_name: str | None = None,
     **kwargs,
 ) -> Path | None:
-    if display_mode == "fiftyone":
-        from lerobot.utils.fiftyone_visualization import serve_fiftyone_dataset_playback
-
-        logging.info("Starting FiftyOne App")
-        serve_fiftyone_dataset_playback(
-            dataset,
-            episode_index,
-            host=host,
-            port=web_port,
-            remote=remote,
-            all_episodes=all_episodes,
-            persistent=persistent,
-            dataset_name=fo_dataset_name,
-        )
-        return None
-
-    if episode_index is None:
-        raise ValueError(
-            f"episode_index is required for display_mode='{display_mode}' (only 'fiftyone' with "
-            "all_episodes=True can omit it)."
-        )
-
     if display_mode == "foxglove":
         from lerobot.utils.foxglove_visualization import serve_foxglove_dataset_playback
 
@@ -554,10 +528,28 @@ def main():
     tolerance_s = kwargs.pop("tolerance_s")
 
     init_logging()
+
+    if args.display_mode == "fiftyone":
+        # FiftyOne reads the on-disk dataset itself, so skip LeRobotDataset (which would load every
+        # frame record of the selected episodes into memory) and hand it the resolved root instead.
+        from lerobot.utils.fiftyone_visualization import serve_fiftyone_dataset_playback
+
+        logging.info("Starting FiftyOne App")
+        serve_fiftyone_dataset_playback(
+            repo_id,
+            args.episode_index,
+            root=root,
+            host=args.host,
+            port=args.web_port,
+            remote=args.remote,
+            all_episodes=args.all_episodes,
+            persistent=args.persistent,
+            dataset_name=args.fo_dataset_name,
+        )
+        return
+
     logging.info("Loading dataset")
-    # With --all-episodes the whole dataset must be on disk for the FiftyOne importer to read.
-    episodes = None if (args.display_mode == "fiftyone" and args.all_episodes) else [args.episode_index]
-    dataset = LeRobotDataset(repo_id, episodes=episodes, root=root, tolerance_s=tolerance_s)
+    dataset = LeRobotDataset(repo_id, episodes=[args.episode_index], root=root, tolerance_s=tolerance_s)
 
     visualize_dataset(dataset, **kwargs)
 

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -71,6 +71,21 @@ local$ lerobot-dataset-viz \
 This starts a Foxglove WebSocket server that serves the episode on demand from the on-disk dataset,
 so you can play/pause and scrub anywhere in the episode using Foxglove's playback controls.
 
+- Visualize data in the FiftyOne App (per-camera video tiles + synchronized State & Action tile).
+  Requires the extra: pip install 'lerobot[fiftyone]'
+```
+local$ lerobot-dataset-viz \
+    --repo-id lerobot/pusht \
+    --episode-index 0 \
+    --display-mode fiftyone
+
+# a browser tab opens at http://localhost:5151; on a headless machine add --remote and
+# forward the port: ssh -N -L 5151:127.0.0.1:5151 user@remote
+```
+FiftyOne imports the episode straight from the on-disk dataset root (no re-encoding). Add
+`--all-episodes` to browse every episode of the dataset. The FiftyOne dataset is kept after exit
+(reopen it with `fiftyone app launch <name>`); pass `--no-persistent` for a throwaway session.
+
 """
 
 import argparse
@@ -159,7 +174,7 @@ def build_blueprint_from_dataset(dataset: LeRobotDataset):
 
 def visualize_dataset(
     dataset: LeRobotDataset,
-    episode_index: int,
+    episode_index: int | None,
     batch_size: int = 32,
     num_workers: int = 0,
     mode: str = "local",
@@ -169,10 +184,36 @@ def visualize_dataset(
     output_dir: Path | None = None,
     display_compressed_images: bool = False,
     display_mode: str = "rerun",
-    host: str = "127.0.0.1",
+    host: str | None = None,
     autoplay: bool = True,
+    remote: bool = False,
+    all_episodes: bool = False,
+    persistent: bool = True,
+    fo_dataset_name: str | None = None,
     **kwargs,
 ) -> Path | None:
+    if display_mode == "fiftyone":
+        from lerobot.utils.fiftyone_visualization import serve_fiftyone_dataset_playback
+
+        logging.info("Starting FiftyOne App")
+        serve_fiftyone_dataset_playback(
+            dataset,
+            episode_index,
+            host=host,
+            port=web_port,
+            remote=remote,
+            all_episodes=all_episodes,
+            persistent=persistent,
+            dataset_name=fo_dataset_name,
+        )
+        return None
+
+    if episode_index is None:
+        raise ValueError(
+            f"episode_index is required for display_mode='{display_mode}' (only 'fiftyone' with "
+            "all_episodes=True can omit it)."
+        )
+
     if display_mode == "foxglove":
         from lerobot.utils.foxglove_visualization import serve_foxglove_dataset_playback
 
@@ -180,7 +221,7 @@ def visualize_dataset(
         serve_foxglove_dataset_playback(
             dataset,
             episode_index,
-            host=host,
+            host=host or "127.0.0.1",
             port=web_port if web_port is not None else DEFAULT_FOXGLOVE_PORT,
             compress_images=display_compressed_images,
             autoplay=autoplay,
@@ -316,8 +357,8 @@ def main():
     parser.add_argument(
         "--episode-index",
         type=int,
-        required=True,
-        help="Episode to visualize.",
+        default=None,
+        help="Episode to visualize. Required unless `--display-mode fiftyone --all-episodes` is used.",
     )
     parser.add_argument(
         "--root",
@@ -360,7 +401,8 @@ def main():
         default=None,
         help=(
             "Web/WebSocket port. For rerun `--mode distant` it is the web viewer port (default 9090); "
-            "for `--display-mode foxglove` it is the server bind port (default 8765)."
+            "for `--display-mode foxglove` it is the server bind port (default 8765); "
+            "for `--display-mode fiftyone` it is the App port (default 5151, or FiftyOne's configured port)."
         ),
     )
     parser.add_argument(
@@ -401,20 +443,24 @@ def main():
         "--display-mode",
         type=str,
         default="rerun",
-        choices=["rerun", "foxglove"],
+        choices=["rerun", "foxglove", "fiftyone"],
         help=(
             "Visualization backend. 'rerun' uses the Rerun viewer (--mode/--save/--*-port apply). "
             "'foxglove' starts a Foxglove WebSocket server that serves the episode as a seekable, "
-            "scrubbable timeline; connect the Foxglove app to ws://HOST:PORT (--host/--web-port)."
+            "scrubbable timeline; connect the Foxglove app to ws://HOST:PORT (--host/--web-port). "
+            "'fiftyone' imports the episode from the on-disk dataset and opens it in the FiftyOne App "
+            "(default http://localhost:5151; --host/--web-port/--remote/--all-episodes apply; "
+            "requires `pip install 'lerobot[fiftyone]'`)."
         ),
     )
     parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
+        default=None,
         help=(
-            "Host to bind the Foxglove WebSocket server to when `--display-mode foxglove` is set "
-            "(127.0.0.1 for local only, 0.0.0.0 for all interfaces)."
+            "Host/interface for the viewer server. For `--display-mode foxglove` it is the WebSocket "
+            "bind address (default 127.0.0.1; 0.0.0.0 for all interfaces). For `--display-mode fiftyone` "
+            "it is the App address (default: FiftyOne's configured address, localhost)."
         ),
     )
     parser.add_argument(
@@ -426,17 +472,80 @@ def main():
             "connects; wait for play to be pressed in the Foxglove app instead."
         ),
     )
+    parser.add_argument(
+        "--remote",
+        action="store_true",
+        help=(
+            "For `--display-mode fiftyone`: run a remote session (no browser is opened; SSH "
+            "port-forwarding instructions are printed instead). Use on a headless machine."
+        ),
+    )
+    parser.add_argument(
+        "--all-episodes",
+        action="store_true",
+        help=(
+            "For `--display-mode fiftyone`: load every episode of the dataset instead of only "
+            "`--episode-index`. The whole dataset is downloaded/read from `--root`."
+        ),
+    )
+    parser.add_argument(
+        "--no-persistent",
+        dest="persistent",
+        action="store_false",
+        help=(
+            "For `--display-mode fiftyone`: don't keep the FiftyOne dataset after exit. By default it is "
+            "kept (and replaced in place on re-run) so tags and saved views made in the App survive and "
+            "it can be reopened with `fiftyone app launch <name>`."
+        ),
+    )
+    parser.add_argument(
+        "--fo-dataset-name",
+        type=str,
+        default=None,
+        help=(
+            "For `--display-mode fiftyone`: name of the FiftyOne dataset to create (default: "
+            "`<repo_id>-episode-<i>`, or `<repo_id>` with `--all-episodes`). An existing dataset with "
+            "this name is replaced."
+        ),
+    )
 
     args = parser.parse_args()
 
-    if args.display_mode == "foxglove":
+    if args.display_mode == "fiftyone" and args.all_episodes:
+        if args.episode_index is not None:
+            logging.warning("`--episode-index` is ignored with `--all-episodes`.")
+    elif args.episode_index is None:
+        parser.error("--episode-index is required unless `--display-mode fiftyone --all-episodes` is used.")
+
+    if args.display_mode != "rerun":
         rerun_only = ("mode", "save", "output_dir", "grpc_port", "batch_size", "num_workers")
         ignored = [name for name in rerun_only if getattr(args, name) != parser.get_default(name)]
         if ignored:
             logging.warning(
                 "These flags only apply to `--display-mode rerun` and are ignored with "
-                "`--display-mode foxglove`: %s.",
+                "`--display-mode %s`: %s.",
+                args.display_mode,
                 ", ".join(f"--{name.replace('_', '-')}" for name in ignored),
+            )
+    if args.display_mode != "foxglove" and not args.autoplay:
+        logging.warning("`--no-autoplay` only applies to `--display-mode foxglove` and is ignored.")
+    if args.display_mode != "fiftyone":
+        # dest -> flag as typed (``persistent`` is set by ``--no-persistent``).
+        fiftyone_only = {
+            "remote": "--remote",
+            "all_episodes": "--all-episodes",
+            "persistent": "--no-persistent",
+            "fo_dataset_name": "--fo-dataset-name",
+        }
+        ignored = [
+            flag for dest, flag in fiftyone_only.items() if getattr(args, dest) != parser.get_default(dest)
+        ]
+        if ignored:
+            logging.warning(
+                "These flags only apply to `--display-mode fiftyone` and are ignored with "
+                "`--display-mode %s`: %s.",
+                args.display_mode,
+                ", ".join(ignored),
             )
 
     kwargs = vars(args)
@@ -446,7 +555,9 @@ def main():
 
     init_logging()
     logging.info("Loading dataset")
-    dataset = LeRobotDataset(repo_id, episodes=[args.episode_index], root=root, tolerance_s=tolerance_s)
+    # With --all-episodes the whole dataset must be on disk for the FiftyOne importer to read.
+    episodes = None if (args.display_mode == "fiftyone" and args.all_episodes) else [args.episode_index]
+    dataset = LeRobotDataset(repo_id, episodes=episodes, root=root, tolerance_s=tolerance_s)
 
     visualize_dataset(dataset, **kwargs)
 

--- a/src/lerobot/utils/fiftyone_visualization.py
+++ b/src/lerobot/utils/fiftyone_visualization.py
@@ -26,12 +26,15 @@ import contextlib
 import logging
 import re
 import shlex
-from typing import TYPE_CHECKING
+from pathlib import Path
 
+from huggingface_hub import snapshot_download
+
+from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
+from lerobot.datasets.utils import get_safe_version, is_valid_version
+
+from .constants import HF_LEROBOT_HUB_CACHE
 from .import_utils import require_package
-
-if TYPE_CHECKING:
-    from lerobot.datasets import LeRobotDataset
 
 # Video codecs the FiftyOne App decodes natively. LeRobot's default encoder (``libsvtav1``) produces
 # ``av1``, so freshly recorded datasets are fine. Other codecs are handed to the browser's WebCodecs
@@ -50,11 +53,57 @@ def _fiftyone_dataset_name(repo_id: str, episode_index: int | None) -> str:
     return base if episode_index is None else f"{base}-episode-{episode_index}"
 
 
-def _check_video_codecs(dataset: "LeRobotDataset") -> None:
+def _episode_files(meta: LeRobotDatasetMetadata, episodes: list[int] | None) -> list[Path]:
+    """Relative ``data/`` and ``videos/`` paths the FiftyOne importer reads for ``episodes`` (all if ``None``)."""
+
+    indices = range(meta.total_episodes) if episodes is None else episodes
+    files: set[Path] = set()
+    for ep in indices:
+        files.add(meta.get_data_file_path(ep))
+        for key in meta.video_keys:
+            files.add(meta.get_video_file_path(ep, key))
+    return sorted(files)
+
+
+def _ensure_files_on_disk(
+    meta: LeRobotDatasetMetadata, episodes: list[int] | None, *, root_requested: bool
+) -> None:
+    """Download whatever the importer needs that isn't already under ``meta.root``.
+
+    Only the missing files are fetched, and nothing is read into memory: unlike `LeRobotDataset`, which
+    loads every frame record of the selected episodes into a Hugging Face `Dataset`, FiftyOne reads
+    the Parquet and video files itself.
+    """
+
+    missing = [str(f) for f in _episode_files(meta, episodes) if not (meta.root / f).exists()]
+    if not missing:
+        return
+
+    revision = meta.revision
+    if is_valid_version(revision):
+        revision = get_safe_version(meta.repo_id, revision)
+    logging.info("Downloading %d file(s) for %s from the Hub", len(missing), meta.repo_id)
+    if root_requested:
+        snapshot_download(
+            meta.repo_id, repo_type="dataset", revision=revision, local_dir=meta.root, allow_patterns=missing
+        )
+    else:
+        meta.root = Path(
+            snapshot_download(
+                meta.repo_id,
+                repo_type="dataset",
+                revision=revision,
+                cache_dir=HF_LEROBOT_HUB_CACHE,
+                allow_patterns=missing,
+            )
+        )
+
+
+def _check_video_codecs(meta: LeRobotDatasetMetadata) -> None:
     """Warn for camera streams whose codec the FiftyOne App doesn't decode natively."""
 
-    for key in dataset.meta.camera_keys:
-        feature = dataset.meta.features.get(key) or {}
+    for key in meta.camera_keys:
+        feature = meta.features.get(key) or {}
         info = feature.get("info") or {}
         codec = info.get("video.codec")
         if codec is not None and codec not in _APP_NATIVE_CODECS:
@@ -68,9 +117,10 @@ def _check_video_codecs(dataset: "LeRobotDataset") -> None:
 
 
 def serve_fiftyone_dataset_playback(
-    dataset: "LeRobotDataset",
+    repo_id: str,
     episode_index: int | None,
     *,
+    root: str | Path | None = None,
     host: str | None = None,
     port: int | None = None,
     remote: bool = False,
@@ -80,17 +130,21 @@ def serve_fiftyone_dataset_playback(
 ) -> None:
     """Open a LeRobot dataset episode in the FiftyOne App and block until interrupted.
 
-    Builds a FiftyOne dataset from the on-disk LeRobot root with `fo.Dataset.from_dir` (the
-    `fiftyone.types.LeRobotDataset` importer), launches the App on it, then waits for Ctrl-C.
-    FiftyOne reads the data parquet and videos itself, so the episode(s) requested here must already
-    be present under `dataset.root` (`LeRobotDataset(repo_id, episodes=[i])` downloads exactly that
-    episode's shards; `all_episodes` needs the full dataset on disk).
+    Resolves the dataset root from `meta/` alone ([`~lerobot.datasets.LeRobotDatasetMetadata`]),
+    downloads any missing `data/` or `videos/` files for the requested episode(s), then builds a
+    FiftyOne dataset from that root with `fo.Dataset.from_dir` (the `fiftyone.types.LeRobotDataset`
+    importer), launches the App on it and waits for Ctrl-C. FiftyOne reads the Parquet and video
+    files itself, so no `LeRobotDataset` is constructed and no frame table is loaded into memory.
 
     Args:
-        dataset (`LeRobotDataset`):
-            Dataset whose `root` holds the episode(s) to visualize.
+        repo_id (`str`):
+            Hub repository id of the dataset (e.g. `lerobot/pusht`), also used for the default
+            FiftyOne dataset name.
         episode_index (`int | None`):
             Episode to load. Ignored when `all_episodes` is `True`; required otherwise.
+        root (`str | Path`, *optional*):
+            Local dataset directory. When omitted, the dataset is looked up in (or downloaded to) the
+            LeRobot cache, as with `LeRobotDataset`.
         host (`str`, *optional*):
             Address the App server binds to. `None` defers to FiftyOne's own config
             (`fo.config.default_app_address`).
@@ -101,7 +155,7 @@ def serve_fiftyone_dataset_playback(
             Run as a remote session: don't open a browser, print SSH port-forwarding instructions
             instead. Use this on a headless machine.
         all_episodes (`bool`, *optional*, defaults to `False`):
-            Load every episode under `dataset.root` instead of just `episode_index`.
+            Load every episode of the dataset instead of just `episode_index`.
         persistent (`bool`, *optional*, defaults to `True`):
             Keep the FiftyOne dataset in the database after exit so it can be reopened with
             `fo.load_dataset(name)` and any tags or saved views made in the App survive. Pass `False`
@@ -123,11 +177,15 @@ def serve_fiftyone_dataset_playback(
         raise ValueError("episode_index is required unless all_episodes=True.")
 
     episodes = None if all_episodes else [episode_index]
-    name = dataset_name or _fiftyone_dataset_name(dataset.repo_id, None if all_episodes else episode_index)
-    # The importer resolves media relative to the dataset root and rejects relative paths.
-    dataset_dir = str(dataset.root.resolve())
+    name = dataset_name or _fiftyone_dataset_name(repo_id, None if all_episodes else episode_index)
 
-    _check_video_codecs(dataset)
+    # Metadata only: this reads (or downloads) ``meta/`` and nothing else.
+    meta = LeRobotDatasetMetadata(repo_id, root=root)
+    _ensure_files_on_disk(meta, episodes, root_requested=root is not None)
+    # The importer resolves media relative to the dataset root and rejects relative paths.
+    dataset_dir = str(meta.root.resolve())
+
+    _check_video_codecs(meta)
 
     logging.info("Importing %s into FiftyOne dataset '%s'", dataset_dir, name)
     fo_dataset = fo.Dataset.from_dir(
@@ -140,7 +198,7 @@ def serve_fiftyone_dataset_playback(
     )
 
     # One FiftyOne sample per episode; check the import produced what was asked for.
-    expected = dataset.meta.total_episodes if all_episodes else 1
+    expected = meta.total_episodes if all_episodes else 1
     imported = len(fo_dataset)
     skipped = (fo_dataset.info.get("lerobot") or {}).get("skipped_episodes") or []
     if imported != expected or skipped:

--- a/src/lerobot/utils/fiftyone_visualization.py
+++ b/src/lerobot/utils/fiftyone_visualization.py
@@ -1,0 +1,202 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FiftyOne visualization backend.
+
+Post-hoc episode playback ([`~lerobot.utils.fiftyone_visualization.serve_fiftyone_dataset_playback`])
+in the FiftyOne App. FiftyOne imports a LeRobot v3 dataset straight from its on-disk root (`meta/`,
+`data/`, `videos/`) and renders each episode with per-camera video tiles and a synchronized State &
+Action tile, so there is no per-frame streaming API: this backend is selectable from
+`lerobot-dataset-viz` only and is not part of the live control-loop dispatch in
+[`~lerobot.utils.visualization_utils`]. Requires the `fiftyone` extra (`pip install 'lerobot[fiftyone]'`).
+"""
+
+import contextlib
+import logging
+import re
+import shlex
+from typing import TYPE_CHECKING
+
+from .import_utils import require_package
+
+if TYPE_CHECKING:
+    from lerobot.datasets import LeRobotDataset
+
+# Video codecs the FiftyOne App decodes natively. LeRobot's default encoder (``libsvtav1``) produces
+# ``av1``, so freshly recorded datasets are fine. Other codecs are handed to the browser's WebCodecs
+# and may or may not play, so they are warned about up front rather than discovered as blank tiles.
+_APP_NATIVE_CODECS = frozenset({"av1", "h264"})
+
+
+def _fiftyone_dataset_name(repo_id: str, episode_index: int | None) -> str:
+    """Default FiftyOne dataset name for a LeRobot ``repo_id`` (and optional single episode).
+
+    FiftyOne dataset names show up in the App's dataset selector and as MongoDB collection names, so
+    anything that isn't alphanumeric, ``-``, ``_`` or ``.`` is collapsed to ``-``.
+    """
+
+    base = re.sub(r"[^A-Za-z0-9_.-]+", "-", repo_id).strip("-")
+    return base if episode_index is None else f"{base}-episode-{episode_index}"
+
+
+def _check_video_codecs(dataset: "LeRobotDataset") -> None:
+    """Warn for camera streams whose codec the FiftyOne App doesn't decode natively."""
+
+    for key in dataset.meta.camera_keys:
+        feature = dataset.meta.features.get(key) or {}
+        info = feature.get("info") or {}
+        codec = info.get("video.codec")
+        if codec is not None and codec not in _APP_NATIVE_CODECS:
+            logging.warning(
+                "FiftyOne: camera '%s' is encoded with '%s'. The FiftyOne App decodes %s natively; other "
+                "codecs depend on your browser's WebCodecs support and may not play.",
+                key,
+                codec,
+                " and ".join(sorted(_APP_NATIVE_CODECS)),
+            )
+
+
+def serve_fiftyone_dataset_playback(
+    dataset: "LeRobotDataset",
+    episode_index: int | None,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    remote: bool = False,
+    all_episodes: bool = False,
+    persistent: bool = True,
+    dataset_name: str | None = None,
+) -> None:
+    """Open a LeRobot dataset episode in the FiftyOne App and block until interrupted.
+
+    Builds a FiftyOne dataset from the on-disk LeRobot root with `fo.Dataset.from_dir` (the
+    `fiftyone.types.LeRobotDataset` importer), launches the App on it, then waits for Ctrl-C.
+    FiftyOne reads the data parquet and videos itself, so the episode(s) requested here must already
+    be present under `dataset.root` (`LeRobotDataset(repo_id, episodes=[i])` downloads exactly that
+    episode's shards; `all_episodes` needs the full dataset on disk).
+
+    Args:
+        dataset (`LeRobotDataset`):
+            Dataset whose `root` holds the episode(s) to visualize.
+        episode_index (`int | None`):
+            Episode to load. Ignored when `all_episodes` is `True`; required otherwise.
+        host (`str`, *optional*):
+            Address the App server binds to. `None` defers to FiftyOne's own config
+            (`fo.config.default_app_address`).
+        port (`int`, *optional*):
+            Port the App server listens on. `None` defers to FiftyOne's own config
+            (`fo.config.default_app_port`, 5151 unless `FIFTYONE_DEFAULT_APP_PORT` is set).
+        remote (`bool`, *optional*, defaults to `False`):
+            Run as a remote session: don't open a browser, print SSH port-forwarding instructions
+            instead. Use this on a headless machine.
+        all_episodes (`bool`, *optional*, defaults to `False`):
+            Load every episode under `dataset.root` instead of just `episode_index`.
+        persistent (`bool`, *optional*, defaults to `True`):
+            Keep the FiftyOne dataset in the database after exit so it can be reopened with
+            `fo.load_dataset(name)` and any tags or saved views made in the App survive. Pass `False`
+            for a throwaway session. Re-running with the same name replaces the dataset in place, so
+            repeated runs don't accumulate.
+        dataset_name (`str`, *optional*):
+            Name for the FiftyOne dataset. Defaults to a sanitized `<repo_id>-episode-<i>` (or
+            `<repo_id>` with `all_episodes`). An existing dataset with this name is replaced.
+
+    Raises:
+        ValueError: If `episode_index` is `None` and `all_episodes` is `False`.
+    """
+
+    require_package("fiftyone", extra="fiftyone")
+    import fiftyone as fo
+    import fiftyone.types as fot
+
+    if not all_episodes and episode_index is None:
+        raise ValueError("episode_index is required unless all_episodes=True.")
+
+    episodes = None if all_episodes else [episode_index]
+    name = dataset_name or _fiftyone_dataset_name(dataset.repo_id, None if all_episodes else episode_index)
+    # The importer resolves media relative to the dataset root and rejects relative paths.
+    dataset_dir = str(dataset.root.resolve())
+
+    _check_video_codecs(dataset)
+
+    logging.info("Importing %s into FiftyOne dataset '%s'", dataset_dir, name)
+    fo_dataset = fo.Dataset.from_dir(
+        dataset_dir=dataset_dir,
+        dataset_type=fot.LeRobotDataset,
+        episodes=episodes,
+        name=name,
+        persistent=persistent,
+        overwrite=True,
+    )
+
+    # One FiftyOne sample per episode; check the import produced what was asked for.
+    expected = dataset.meta.total_episodes if all_episodes else 1
+    imported = len(fo_dataset)
+    skipped = (fo_dataset.info.get("lerobot") or {}).get("skipped_episodes") or []
+    if imported != expected or skipped:
+        logging.warning(
+            "FiftyOne: imported %d of %d episode(s); %d skipped%s.",
+            imported,
+            expected,
+            len(skipped),
+            f" ({'; '.join(map(str, skipped))})" if skipped else "",
+        )
+
+    session = fo.launch_app(fo_dataset, port=port, address=host, remote=remote)
+    if not remote:
+        print(f"FiftyOne App running at {session.url}")
+    print("Ctrl-C to exit.")
+    with contextlib.suppress(KeyboardInterrupt):
+        session.wait(-1)
+    # Leading newline: the terminal echoes ``^C`` on the current line, which would offset the box.
+    print("\n" + _exit_message(name, persistent))
+    # No explicit ``session.close()``: FiftyOne's documented script pattern is ``launch_app()`` +
+    # ``wait()``, with the App shutting down when the process exits (``close()`` is for interactive
+    # sessions that keep running afterwards, and can block on the server's open event stream here).
+
+
+def _boxed(title: str, lines: list[str]) -> str:
+    """Render ``lines`` inside a box-drawing frame whose top edge carries ``title``."""
+
+    inner = max(len(line) for line in lines + [title]) + 2  # one space of padding each side
+    top = f"┌─ {title} " + "─" * (inner - len(title) - 3) + "┐"
+    body = [f"│ {line.ljust(inner - 2)} │" for line in lines]
+    bottom = "└" + "─" * inner + "┘"
+    return "\n".join([top, *body, bottom])
+
+
+def _exit_message(name: str, persistent: bool) -> str:
+    """What to print after the App is closed: how to get back to the FiftyOne dataset (or that it's gone)."""
+
+    if not persistent:
+        return (
+            f"FiftyOne App closed. Dataset '{name}' was temporary; drop --no-persistent to keep tags "
+            "and views between runs."
+        )
+    return _boxed(
+        "FiftyOne",
+        [
+            f"Dataset saved: {name}",
+            "",
+            "Reopen from the terminal:",
+            f"  fiftyone app launch {shlex.quote(name)}",
+            "",
+            "Reopen from Python:",
+            "  import fiftyone as fo",
+            f'  dataset = fo.load_dataset("{name}")',
+            "  session = fo.launch_app(dataset)",
+            "  session.wait()",
+            "",
+            "Learn more: https://docs.voxel51.com/user_guide/index.html",
+        ],
+    )

--- a/src/lerobot/utils/fiftyone_visualization.py
+++ b/src/lerobot/utils/fiftyone_visualization.py
@@ -251,7 +251,7 @@ def _exit_message(name: str, persistent: bool) -> str:
             "",
             "Reopen from Python:",
             "  import fiftyone as fo",
-            f'  dataset = fo.load_dataset("{name}")',
+            f"  dataset = fo.load_dataset({name!r})",
             "  session = fo.launch_app(dataset)",
             "  session.wait()",
             "",

--- a/tests/utils/test_fiftyone_visualization.py
+++ b/tests/utils/test_fiftyone_visualization.py
@@ -217,7 +217,7 @@ def test_exit_message_persistent_is_runnable_and_boxed(fake_fo, fake_meta, capsy
     out = capsys.readouterr().out
     assert "Dataset saved: user-my-dataset-episode-0" in out
     assert "fiftyone app launch user-my-dataset-episode-0" in out
-    assert 'fo.load_dataset("user-my-dataset-episode-0")' in out
+    assert "fo.load_dataset('user-my-dataset-episode-0')" in out
     assert "https://docs.voxel51.com/user_guide/index.html" in out
     # Every line of the box is the same width, including the title edge.
     box = [line for line in out.splitlines() if line and line[0] in "┌│└"]
@@ -225,8 +225,10 @@ def test_exit_message_persistent_is_runnable_and_boxed(fake_fo, fake_meta, capsy
     assert len({len(line) for line in box}) == 1
 
 
-def test_exit_message_shell_quotes_dataset_name():
-    assert "fiftyone app launch 'my dataset'" in fv._exit_message("my dataset", persistent=True)
+def test_exit_message_quotes_dataset_name_for_shell_and_python():
+    msg = fv._exit_message('my "dataset"', persistent=True)
+    assert "fiftyone app launch 'my \"dataset\"'" in msg
+    assert "fo.load_dataset('my \"dataset\"')" in msg  # repr: valid Python whatever the name contains
 
 
 def test_exit_message_non_persistent(fake_fo, fake_meta, capsys):

--- a/tests/utils/test_fiftyone_visualization.py
+++ b/tests/utils/test_fiftyone_visualization.py
@@ -80,22 +80,64 @@ def fake_fo(monkeypatch):
     return SimpleNamespace(calls=calls, session=session, fo_dataset=fo_dataset, fot=fot)
 
 
-def _make_dataset(tmp_path: Path, total_episodes: int = 3, codec: str = "av1"):
-    features = {
-        "observation.images.front": {
-            "dtype": "video",
-            "shape": [3, 480, 640],
-            "info": {"video.codec": codec},
-        },
-        "observation.state": {"dtype": "float32", "shape": [6]},
-        "action": {"dtype": "float32", "shape": [6]},
-    }
-    meta = SimpleNamespace(
-        camera_keys=["observation.images.front"],
-        features=features,
-        total_episodes=total_episodes,
-    )
-    return SimpleNamespace(repo_id="user/my dataset", root=tmp_path / "ds", meta=meta)
+_CAM = "observation.images.front"
+
+
+class _FakeMeta:
+    """Stand-in for ``LeRobotDatasetMetadata``: one data shard and one video per episode."""
+
+    def __init__(self, repo_id: str, root: Path, total_episodes: int = 3, codec: str = "av1"):
+        self.repo_id = repo_id
+        self.root = root
+        self.revision = "v3.0"
+        self.total_episodes = total_episodes
+        self.camera_keys = [_CAM]
+        self.video_keys = [_CAM]
+        self.features = {
+            _CAM: {"dtype": "video", "shape": [3, 480, 640], "info": {"video.codec": codec}},
+            "observation.state": {"dtype": "float32", "shape": [6]},
+            "action": {"dtype": "float32", "shape": [6]},
+        }
+
+    def get_data_file_path(self, ep: int) -> Path:
+        return Path(f"data/chunk-000/file-{ep:03d}.parquet")
+
+    def get_video_file_path(self, ep: int, key: str) -> Path:
+        return Path(f"videos/{key}/chunk-000/file-{ep:03d}.mp4")
+
+    def write_files(self, episodes) -> None:
+        for ep in episodes:
+            for rel in (self.get_data_file_path(ep), self.get_video_file_path(ep, _CAM)):
+                (self.root / rel).parent.mkdir(parents=True, exist_ok=True)
+                (self.root / rel).touch()
+
+
+@pytest.fixture
+def fake_meta(monkeypatch, tmp_path):
+    """Replace ``LeRobotDatasetMetadata`` with ``_FakeMeta`` (all 3 episodes on disk) and stub the Hub."""
+    state = {"meta": None, "downloads": []}
+    opts = {"total_episodes": 3, "codec": "av1"}
+
+    def make_meta(repo_id, root=None):
+        meta = _FakeMeta(repo_id, Path(root) if root is not None else tmp_path / "cache", **opts)
+        state["meta"] = meta
+        return meta
+
+    def snapshot_download(repo_id, **kwargs):
+        state["downloads"].append({"repo_id": repo_id, **kwargs})
+        return str(kwargs.get("local_dir", tmp_path / "cache"))
+
+    monkeypatch.setattr(fv, "LeRobotDatasetMetadata", make_meta)
+    monkeypatch.setattr(fv, "snapshot_download", snapshot_download)
+    monkeypatch.setattr(fv, "get_safe_version", lambda repo_id, rev: rev)
+
+    root = tmp_path / "ds"
+    _FakeMeta("user/my dataset", root).write_files(range(3))
+    return SimpleNamespace(state=state, opts=opts, root=root, repo_id="user/my dataset")
+
+
+def _serve(fake_meta, episode_index, **kwargs):
+    return fv.serve_fiftyone_dataset_playback(fake_meta.repo_id, episode_index, root=fake_meta.root, **kwargs)
 
 
 def test_dataset_name_sanitization():
@@ -104,12 +146,11 @@ def test_dataset_name_sanitization():
     assert fv._fiftyone_dataset_name("user/my dataset!", 2) == "user-my-dataset-episode-2"
 
 
-def test_single_episode_playback(fake_fo, tmp_path):
-    dataset = _make_dataset(tmp_path)
-    fv.serve_fiftyone_dataset_playback(dataset, 1, host="0.0.0.0", port=5252, remote=True)
+def test_single_episode_playback(fake_fo, fake_meta):
+    _serve(fake_meta, 1, host="0.0.0.0", port=5252, remote=True)
 
     from_dir = fake_fo.calls["from_dir"]
-    assert from_dir["dataset_dir"] == str((tmp_path / "ds").resolve())
+    assert from_dir["dataset_dir"] == str(fake_meta.root.resolve())
     assert Path(from_dir["dataset_dir"]).is_absolute()
     assert from_dir["dataset_type"] is fake_fo.fot.LeRobotDataset
     assert from_dir["episodes"] == [1]
@@ -125,29 +166,54 @@ def test_single_episode_playback(fake_fo, tmp_path):
     assert not fake_fo.session.closed
 
 
-def test_defaults_defer_to_fiftyone_config(fake_fo, tmp_path):
-    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+def test_defaults_defer_to_fiftyone_config(fake_fo, fake_meta):
+    _serve(fake_meta, 0)
     launch = fake_fo.calls["launch_app"]
     assert launch["port"] is None and launch["address"] is None and launch["remote"] is False
 
 
-def test_all_episodes_and_custom_name(fake_fo, tmp_path):
+def test_all_episodes_and_custom_name(fake_fo, fake_meta):
     fake_fo.fo_dataset.n = 3
-    fv.serve_fiftyone_dataset_playback(
-        _make_dataset(tmp_path, total_episodes=3),
-        None,
-        all_episodes=True,
-        persistent=False,
-        dataset_name="mine",
-    )
+    _serve(fake_meta, None, all_episodes=True, persistent=False, dataset_name="mine")
     from_dir = fake_fo.calls["from_dir"]
     assert from_dir["episodes"] is None
     assert from_dir["name"] == "mine"
     assert from_dir["persistent"] is False
 
 
-def test_exit_message_persistent_is_runnable_and_boxed(fake_fo, tmp_path, capsys):
-    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+def test_no_download_when_files_are_local(fake_fo, fake_meta):
+    """A dataset already on disk (e.g. ``--root``) is never touched on the Hub, even with all episodes."""
+    _serve(fake_meta, None, all_episodes=True)
+    assert fake_meta.state["downloads"] == []
+
+
+def test_downloads_only_missing_files_for_requested_episode(fake_fo, fake_meta):
+    for rel in (fake_meta.root / "data/chunk-000/file-001.parquet",):
+        rel.unlink()
+    _serve(fake_meta, 1)
+
+    (download,) = fake_meta.state["downloads"]
+    assert download["repo_id"] == fake_meta.repo_id
+    assert download["repo_type"] == "dataset"
+    assert download["local_dir"] == fake_meta.root  # --root given: materialize there, like LeRobotDataset
+    assert download["allow_patterns"] == ["data/chunk-000/file-001.parquet"]  # only what's missing
+
+
+def test_missing_episode_files_go_to_cache_without_root(fake_fo, fake_meta, tmp_path):
+    fv.serve_fiftyone_dataset_playback(fake_meta.repo_id, 0)  # no root: nothing exists under the fake cache
+    (download,) = fake_meta.state["downloads"]
+    assert "local_dir" not in download
+    assert download["cache_dir"] == fv.HF_LEROBOT_HUB_CACHE
+    assert set(download["allow_patterns"]) == {
+        "data/chunk-000/file-000.parquet",
+        f"videos/{_CAM}/chunk-000/file-000.mp4",
+    }
+    # The importer is pointed at the snapshot returned by the download.
+    assert fake_fo.calls["from_dir"]["dataset_dir"] == str((tmp_path / "cache").resolve())
+
+
+def test_exit_message_persistent_is_runnable_and_boxed(fake_fo, fake_meta, capsys):
+    _serve(fake_meta, 0)
     out = capsys.readouterr().out
     assert "Dataset saved: user-my-dataset-episode-0" in out
     assert "fiftyone app launch user-my-dataset-episode-0" in out
@@ -163,49 +229,50 @@ def test_exit_message_shell_quotes_dataset_name():
     assert "fiftyone app launch 'my dataset'" in fv._exit_message("my dataset", persistent=True)
 
 
-def test_exit_message_non_persistent(fake_fo, tmp_path, capsys):
-    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0, persistent=False)
+def test_exit_message_non_persistent(fake_fo, fake_meta, capsys):
+    _serve(fake_meta, 0, persistent=False)
     out = capsys.readouterr().out
     assert "was temporary" in out
     assert "fiftyone app launch" not in out
 
 
-def test_requires_episode_index_without_all_episodes(fake_fo, tmp_path):
+def test_requires_episode_index_without_all_episodes(fake_fo, fake_meta):
     with pytest.raises(ValueError, match="episode_index is required"):
-        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), None)
+        _serve(fake_meta, None)
     assert fake_fo.calls["from_dir"] is None
 
 
-def test_warns_on_skipped_or_missing_episodes(fake_fo, tmp_path, caplog):
+def test_warns_on_skipped_or_missing_episodes(fake_fo, fake_meta, caplog):
     fake_fo.fo_dataset.n = 2
     fake_fo.fo_dataset.info["lerobot"]["skipped_episodes"] = ["episode 2: missing video"]
     with caplog.at_level(logging.WARNING):
-        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, total_episodes=3), None, all_episodes=True)
+        _serve(fake_meta, None, all_episodes=True)
     assert "imported 2 of 3 episode(s); 1 skipped" in caplog.text
     assert "missing video" in caplog.text
     # The App is still launched so the user can inspect what did import.
     assert fake_fo.calls["launch_app"] is not None
 
 
-def test_warns_on_unsupported_codec(fake_fo, tmp_path, caplog):
+def test_warns_on_unsupported_codec(fake_fo, fake_meta, caplog):
     with caplog.at_level(logging.WARNING):
-        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, codec="hevc"), 0)
+        fake_meta.opts["codec"] = "hevc"
+        _serve(fake_meta, 0)
     assert "encoded with 'hevc'" in caplog.text
     assert "av1 and h264" in caplog.text
 
 
-def test_no_codec_warning_for_supported_codec(fake_fo, tmp_path, caplog):
+def test_no_codec_warning_for_supported_codec(fake_fo, fake_meta, caplog):
     with caplog.at_level(logging.WARNING):
-        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, codec="av1"), 0)
+        _serve(fake_meta, 0)
     assert "encoded with" not in caplog.text
 
 
-def test_keyboard_interrupt_returns_without_closing_session(fake_fo, tmp_path):
+def test_keyboard_interrupt_returns_without_closing_session(fake_fo, fake_meta):
     """Ctrl-C must return normally and must NOT call ``session.close()`` (it deadlocks in FiftyOne)."""
 
     def interrupt(wait):
         raise KeyboardInterrupt
 
     fake_fo.session.wait = interrupt
-    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+    _serve(fake_meta, 0)
     assert not fake_fo.session.closed

--- a/tests/utils/test_fiftyone_visualization.py
+++ b/tests/utils/test_fiftyone_visualization.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the FiftyOne dataset-playback backend.
+
+A fake ``fiftyone`` package is injected into ``sys.modules`` so these run without FiftyOne (or its
+MongoDB backend) installed; they check how the backend drives the FiftyOne API, not FiftyOne itself.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from lerobot.utils import fiftyone_visualization as fv
+
+
+class _FakeFiftyOneDataset:
+    def __init__(self):
+        self.info = {"lerobot": {"skipped_episodes": []}}
+        self.n = 1
+
+    def __len__(self):
+        return self.n
+
+
+class _FakeSession:
+    def __init__(self):
+        self.url = "http://localhost:5151/"
+        self.wait_calls = []
+        self.closed = False
+
+    def wait(self, wait):
+        self.wait_calls.append(wait)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_fo(monkeypatch):
+    """Install fake ``fiftyone`` / ``fiftyone.types`` modules and bypass ``require_package``."""
+    calls = {"from_dir": None, "launch_app": None}
+    session = _FakeSession()
+    fo_dataset = _FakeFiftyOneDataset()
+
+    def from_dir(**kwargs):
+        calls["from_dir"] = kwargs
+        return fo_dataset
+
+    def launch_app(dataset, **kwargs):
+        calls["launch_app"] = {"dataset": dataset, **kwargs}
+        return session
+
+    fo = ModuleType("fiftyone")
+    fo.Dataset = SimpleNamespace(from_dir=from_dir)
+    fo.launch_app = launch_app
+    fot = ModuleType("fiftyone.types")
+    fot.LeRobotDataset = object()
+    fo.types = fot
+
+    monkeypatch.setitem(sys.modules, "fiftyone", fo)
+    monkeypatch.setitem(sys.modules, "fiftyone.types", fot)
+    monkeypatch.setattr(fv, "require_package", lambda *a, **k: None)
+    return SimpleNamespace(calls=calls, session=session, fo_dataset=fo_dataset, fot=fot)
+
+
+def _make_dataset(tmp_path: Path, total_episodes: int = 3, codec: str = "av1"):
+    features = {
+        "observation.images.front": {
+            "dtype": "video",
+            "shape": [3, 480, 640],
+            "info": {"video.codec": codec},
+        },
+        "observation.state": {"dtype": "float32", "shape": [6]},
+        "action": {"dtype": "float32", "shape": [6]},
+    }
+    meta = SimpleNamespace(
+        camera_keys=["observation.images.front"],
+        features=features,
+        total_episodes=total_episodes,
+    )
+    return SimpleNamespace(repo_id="user/my dataset", root=tmp_path / "ds", meta=meta)
+
+
+def test_dataset_name_sanitization():
+    assert fv._fiftyone_dataset_name("lerobot/pusht", 0) == "lerobot-pusht-episode-0"
+    assert fv._fiftyone_dataset_name("lerobot/pusht", None) == "lerobot-pusht"
+    assert fv._fiftyone_dataset_name("user/my dataset!", 2) == "user-my-dataset-episode-2"
+
+
+def test_single_episode_playback(fake_fo, tmp_path):
+    dataset = _make_dataset(tmp_path)
+    fv.serve_fiftyone_dataset_playback(dataset, 1, host="0.0.0.0", port=5252, remote=True)
+
+    from_dir = fake_fo.calls["from_dir"]
+    assert from_dir["dataset_dir"] == str((tmp_path / "ds").resolve())
+    assert Path(from_dir["dataset_dir"]).is_absolute()
+    assert from_dir["dataset_type"] is fake_fo.fot.LeRobotDataset
+    assert from_dir["episodes"] == [1]
+    assert from_dir["name"] == "user-my-dataset-episode-1"
+    assert from_dir["persistent"] is True  # kept by default so App tags/views survive
+    assert from_dir["overwrite"] is True  # ... but re-running replaces it rather than accumulating
+
+    launch = fake_fo.calls["launch_app"]
+    assert launch["dataset"] is fake_fo.fo_dataset
+    assert launch == {"dataset": fake_fo.fo_dataset, "port": 5252, "address": "0.0.0.0", "remote": True}
+
+    assert fake_fo.session.wait_calls == [-1]
+    assert not fake_fo.session.closed
+
+
+def test_defaults_defer_to_fiftyone_config(fake_fo, tmp_path):
+    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+    launch = fake_fo.calls["launch_app"]
+    assert launch["port"] is None and launch["address"] is None and launch["remote"] is False
+
+
+def test_all_episodes_and_custom_name(fake_fo, tmp_path):
+    fake_fo.fo_dataset.n = 3
+    fv.serve_fiftyone_dataset_playback(
+        _make_dataset(tmp_path, total_episodes=3),
+        None,
+        all_episodes=True,
+        persistent=False,
+        dataset_name="mine",
+    )
+    from_dir = fake_fo.calls["from_dir"]
+    assert from_dir["episodes"] is None
+    assert from_dir["name"] == "mine"
+    assert from_dir["persistent"] is False
+
+
+def test_exit_message_persistent_is_runnable_and_boxed(fake_fo, tmp_path, capsys):
+    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+    out = capsys.readouterr().out
+    assert "Dataset saved: user-my-dataset-episode-0" in out
+    assert "fiftyone app launch user-my-dataset-episode-0" in out
+    assert 'fo.load_dataset("user-my-dataset-episode-0")' in out
+    assert "https://docs.voxel51.com/user_guide/index.html" in out
+    # Every line of the box is the same width, including the title edge.
+    box = [line for line in out.splitlines() if line and line[0] in "┌│└"]
+    assert len(box) >= 3
+    assert len({len(line) for line in box}) == 1
+
+
+def test_exit_message_shell_quotes_dataset_name():
+    assert "fiftyone app launch 'my dataset'" in fv._exit_message("my dataset", persistent=True)
+
+
+def test_exit_message_non_persistent(fake_fo, tmp_path, capsys):
+    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0, persistent=False)
+    out = capsys.readouterr().out
+    assert "was temporary" in out
+    assert "fiftyone app launch" not in out
+
+
+def test_requires_episode_index_without_all_episodes(fake_fo, tmp_path):
+    with pytest.raises(ValueError, match="episode_index is required"):
+        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), None)
+    assert fake_fo.calls["from_dir"] is None
+
+
+def test_warns_on_skipped_or_missing_episodes(fake_fo, tmp_path, caplog):
+    fake_fo.fo_dataset.n = 2
+    fake_fo.fo_dataset.info["lerobot"]["skipped_episodes"] = ["episode 2: missing video"]
+    with caplog.at_level(logging.WARNING):
+        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, total_episodes=3), None, all_episodes=True)
+    assert "imported 2 of 3 episode(s); 1 skipped" in caplog.text
+    assert "missing video" in caplog.text
+    # The App is still launched so the user can inspect what did import.
+    assert fake_fo.calls["launch_app"] is not None
+
+
+def test_warns_on_unsupported_codec(fake_fo, tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, codec="hevc"), 0)
+    assert "encoded with 'hevc'" in caplog.text
+    assert "av1 and h264" in caplog.text
+
+
+def test_no_codec_warning_for_supported_codec(fake_fo, tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path, codec="av1"), 0)
+    assert "encoded with" not in caplog.text
+
+
+def test_keyboard_interrupt_returns_without_closing_session(fake_fo, tmp_path):
+    """Ctrl-C must return normally and must NOT call ``session.close()`` (it deadlocks in FiftyOne)."""
+
+    def interrupt(wait):
+        raise KeyboardInterrupt
+
+    fake_fo.session.wait = interrupt
+    fv.serve_fiftyone_dataset_playback(_make_dataset(tmp_path), 0)
+    assert not fake_fo.session.closed


### PR DESCRIPTION
## Summary / Motivation

Adds `--display-mode fiftyone` to `lerobot-dataset-viz`, alongside the existing Rerun and Foxglove backends. FiftyOne reads the LeRobot v3 layout (`meta/`, `data/`, `videos/`) directly, so no frames are decoded or re-encoded up front: the dataset is imported in a few milliseconds and browsed in the FiftyOne App (browser-based, works over SSH with `--remote`). It can show a single episode or the whole dataset at once (`--all-episodes`), and the imported dataset is persistent by default so tags and saved views made in the App survive closing the viewer.

Design notes:
- Follows the same pattern as the Foxglove backend: own module (`lerobot/utils/fiftyone_visualization.py`), SDK imported lazily behind `require_package`, dependency in a `pyproject.toml` extra.
- FiftyOne lives in its **own extra** (`lerobot[fiftyone]`) rather than `viz`, since it pulls in a MongoDB binary (~200 MB) that `viz` users shouldn't download by accident.
- Post-hoc dataset playback only; the live teleop/record control loop (`visualization_utils.py`) is untouched.

Disclosure: I work at Voxel51, the maintainer of FiftyOne. Parts of this PR were drafted with AI assistance and reviewed/tested by hand.

## Related issues

- Related: #3902 (Foxglove backend, which this mirrors)

## What changed

- New `src/lerobot/utils/fiftyone_visualization.py` with `serve_fiftyone_dataset_playback(repo_id, episode_index, root=...)`: resolves the dataset root via `LeRobotDatasetMetadata` (reads/downloads `meta/` only), downloads just the `data/` and `videos/` files the importer needs that aren't already on disk, imports via `fo.Dataset.from_dir(..., dataset_type=fot.LeRobotDataset)`, launches the App, waits for Ctrl-C, and prints how to reopen the saved dataset. No `LeRobotDataset` is constructed, so no frame table is loaded into memory.
- `lerobot-dataset-viz`: `--display-mode fiftyone`; new flags `--all-episodes`, `--remote`, `--no-persistent`, `--fo-dataset-name`. `--episode-index` is now optional (required unless `--all-episodes`).
- `pyproject.toml`: new `fiftyone` extra (`fiftyone>=1.23.0,<2.0.0`), also included in `all`; `typos` allowlist for the `fo`/`fot` aliases.
- Docs: `installation.mdx` (extras table) and `using_dataset_tools.mdx` (usage section).
- No breaking changes; Rerun and Foxglove paths are unchanged.

## How was this tested (or how to run locally)

- Tests added: `tests/utils/test_fiftyone_visualization.py` (15 tests). FiftyOne is faked in `sys.modules`, so the tests run without the extra installed.
  `uv run pytest -q tests/utils/test_fiftyone_visualization.py tests/scripts -k "fiftyone or dataset_viz"`
- Manual: ran single-episode (local `--root` and Hub download), `--all-episodes`, `--remote`, and `--no-persistent` against local LeRobot v3 datasets; confirmed clean shutdown on Ctrl-C and that the dataset reopens with `fiftyone app launch <name>`.
- Reviewer repro:
  ```bash
  pip install 'lerobot[fiftyone]'
  lerobot-dataset-viz --repo-id lerobot/pusht --episode-index 0 --display-mode fiftyone
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Opened as a **draft**: the `LeRobotDataset` importer ships in FiftyOne 1.23.0, which is not on PyPI yet (latest is 1.21.0). I'll run `uv lock` and mark ready for review once it's released.
- `session.wait()` is followed by process exit rather than `session.close()`; this matches FiftyOne's own `fiftyone app launch` CLI and avoids a deadlock in `Session.close()` when `remote=True` (being fixed on the FiftyOne side). See the comment in `fiftyone_visualization.py`.
