### PR TITLE
fix(libero): document SmolVLA n_action_steps recipe and warn on non-20 Hz fps

### DIFF
--- a/docs/source/libero.mdx
+++ b/docs/source/libero.mdx
@@ -180,6 +180,43 @@ lerobot-train \
 
 To share the result on the Hub, replace `--policy.push_to_hub=false` with `--policy.repo_id=${HF_USER}/libero-smolvla`. Evaluate saved checkpoints with `lerobot-eval` as shown in the [Evaluation](#evaluation) section.
 
+## Evaluating SmolVLA on LIBERO
+
+The Hub checkpoints [`lerobot/smolvla_libero`](https://huggingface.co/lerobot/smolvla_libero) and [`HuggingFaceVLA/smolvla_libero`](https://huggingface.co/HuggingFaceVLA/smolvla_libero) are trained for LIBERO. When evaluating, **override `n_action_steps`** — do not trust the Hub default alone.
+
+### Why `n_action_steps` matters
+
+`n_action_steps` is how many actions from each predicted chunk are executed before the policy looks at the scene again. SmolVLA's `chunk_size` is 50, and some Hub configs set `n_action_steps=50`, which plays the full chunk open-loop.
+
+The [SmolVLA paper](https://huggingface.co/papers/2506.01844) Table 13 already shows that executing 50 actions is the worst setting on LIBERO (about 51.8% average), while **10 steps averages about 82.8%** and 1 step about 80.3%. Independent paired evals on `lerobot/smolvla_libero` see a similar ~20 pp drop when forcing 50 vs 10 (see [#4614](https://github.com/huggingface/lerobot/issues/4614)).
+
+Use **`--policy.n_action_steps=10`** for the paper-aligned recipe. `--policy.n_action_steps=1` is also strong and matches `HuggingFaceVLA/smolvla_libero`'s saved config.
+
+<Tip warning={true}>
+  `lerobot/smolvla_libero` currently ships `n_action_steps: 50` in its Hub
+  `config.json`. Until that Hub config is updated, always pass
+  `--policy.n_action_steps=10` (or `1`) on the CLI — otherwise `lerobot-eval`
+  will open-loop the full 50-step chunk and under-report success.
+</Tip>
+
+### Evaluation command
+
+```bash
+lerobot-eval \
+  --policy.path=lerobot/smolvla_libero \
+  --policy.n_action_steps=10 \
+  --env.type=libero \
+  --env.task=libero_spatial,libero_object,libero_goal,libero_10 \
+  --env.fps=20 \
+  --eval.batch_size=1 \
+  --eval.n_episodes=10 \
+  --env.max_parallel_tasks=1
+```
+
+Keep `--env.fps=20` (the LiberoEnv default). LIBERO actions are deltas; a different control rate changes how far each action moves the arm and can collapse success rates.
+
+If camera keys do not match the checkpoint (for example older `lerobot/smolvla_libero` builds), pass an explicit `--rename_map` as documented in [Rename Map](./rename_map). Empty CLI defaults can overwrite a saved map — see [#4578](https://github.com/huggingface/lerobot/issues/4578).
+
 ## Reproducing published results
 
 We reproduce the results of Pi0.5 on the LIBERO benchmark. We take the Physical Intelligence LIBERO base model (`pi05_libero`) and finetune for an additional 6k steps in bfloat16, with batch size of 256 on 8 H100 GPUs using the [HuggingFace LIBERO dataset](https://huggingface.co/datasets/HuggingFaceVLA/libero).

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import abc
 import importlib
+import logging
 from dataclasses import dataclass, field, fields
 from typing import Any
 
@@ -43,6 +44,8 @@ from lerobot.utils.constants import (
     OBS_IMAGES,
     OBS_STATE,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _make_vec_env_cls(use_async: bool, n_envs: int):
@@ -357,6 +360,14 @@ class LiberoEnv(EnvConfig):
     def __post_init__(self):
         if self.fps <= 0:
             raise ValueError(f"fps must be positive, got {self.fps}")
+        if self.fps != 20:
+            logger.warning(
+                "LiberoEnv fps=%s differs from the standard 20 Hz control rate. "
+                "LIBERO uses delta actions, so a different rate changes how far each "
+                "action moves the arm and can severely hurt success rates. Prefer --env.fps=20 "
+                "unless you intentionally retarget control frequency.",
+                self.fps,
+            )
         if not self.hard_reset and not self.init_states:
             raise ValueError("hard_reset=False requires init_states=True")
 

--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 import os
 import re
 from collections import defaultdict
@@ -33,6 +34,8 @@ from libero.libero.envs import OffScreenRenderEnv
 from lerobot.lerobot_types import RobotObservation
 
 from .utils import _LazyAsyncVectorEnv, parse_camera_names
+
+logger = logging.getLogger(__name__)
 
 
 def _get_suite(name: str) -> benchmark.Benchmark:
@@ -133,6 +136,14 @@ class LiberoEnv(gym.Env):
         super().__init__()
         if control_freq <= 0:
             raise ValueError(f"control_freq must be positive, got {control_freq}")
+        if control_freq != 20:
+            logger.warning(
+                "LiberoEnv control_freq=%s differs from the standard 20 Hz rate. "
+                "LIBERO uses delta actions, so a different rate changes how far each "
+                "action moves the arm and can severely hurt success rates. Prefer fps/control_freq=20 "
+                "unless you intentionally retarget control frequency.",
+                control_freq,
+            )
         if not hard_reset and not init_states:
             raise ValueError("hard_reset=False requires init_states=True")
         self.task_id = task_id

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -46,6 +46,19 @@ def test_libero_rejects_nonpositive_fps():
         LiberoEnv(fps=0)
 
 
+def test_libero_warns_when_fps_not_20(caplog):
+    """Delta-action LIBERO evals at non-20 Hz silently change action scale; warn loudly."""
+    with caplog.at_level(logging.WARNING, logger="lerobot.envs.configs"):
+        LiberoEnv(fps=10)
+    assert any("fps=10" in r.message and "20 Hz" in r.message for r in caplog.records)
+
+
+def test_libero_default_fps_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING, logger="lerobot.envs.configs"):
+        LiberoEnv()
+    assert not any("differs from the standard 20 Hz" in r.message for r in caplog.records)
+
+
 def test_identity_processors():
     """Base class get_env_processors() returns identity pipelines."""
     cfg = make_env_config("aloha")


### PR DESCRIPTION
## Summary / Motivation

`lerobot/smolvla_libero` ships `n_action_steps: 50` on the Hub, so default `lerobot-eval` open-loops the full action chunk. The SmolVLA paper (Table 13) already shows that is the worst LIBERO setting (~51.8% vs ~82.8% at 10 steps / ~80.3% at 1). Issue #4614 reproduces ~20 pp drops in paired runs.

We cannot rewrite the Hub `config.json` from this repo without org write access, so this PR fixes the repo side: document the working eval recipe and catch the related easy footgun where `--env.fps != 20` silently rescales delta actions.

## Related issues

- Fixes: #4614
- Related: #4578 (rename_map CLI default can overwrite saved maps; called out in the new docs)

## What changed

- **Docs (`docs/source/libero.mdx`)**: new "Evaluating SmolVLA on LIBERO" section recommending `--policy.n_action_steps=10` (paper-aligned; `1` also noted), explaining why 50 hurts, keeping `--env.fps=20`, and warning that Hub `lerobot/smolvla_libero` still has 50 until maintainers update it.
- **Code**: warn when `LiberoEnv` config `fps != 20` and when the gym env gets `control_freq != 20` (delta-action scale depends on control rate).
- **Tests**: assert the non-20 Hz warning fires / default 20 Hz stays quiet.

**Not changed (on purpose):**
- Global `SmolVLAConfig.n_action_steps=50` default (architecture / non-LIBERO default; Hub checkpoint still owns the bad LIBERO value).
- Hub `lerobot/smolvla_libero` `config.json`; maintainers with org write should set `n_action_steps` to `10` (or `1`) there as a follow-up.

## How was this tested (or how to run locally)

```bash
uv sync --locked --extra test
uv run pytest -q tests/envs/test_dispatch.py
# 14 passed

PATH="$(uv python find 3.12 | xargs dirname):$PATH" \
  uvx --with pre-commit pre-commit run --files \
    docs/source/libero.mdx src/lerobot/envs/configs.py \
    src/lerobot/envs/libero.py tests/envs/test_dispatch.py
# all hooks passed
```

Full LIBERO + SmolVLA success-rate re-measurement needs GPU + MuJoCo / `.[libero]` and was **not** re-run here; numbers in the docs cite the paper Table 13 and the paired evidence already in #4614.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit` on touched files)
- [x] Focused tests pass locally (`tests/envs/test_dispatch.py`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: # (happy to review a related PR if pointed)

## Reviewer notes

- Please treat Hub `n_action_steps` update as a maintainer follow-up; this PR only documents the CLI override.
- Warning is intentionally loud but non-fatal so intentional retargeting still works.
