### PR TITLE
perf(multi_task_dit): compile the vision encoder and DiT, dedup task strings in the processor

### DIFF
--- a/docs/source/policy_multi_task_dit_README.md
+++ b/docs/source/policy_multi_task_dit_README.md
@@ -1,5 +1,13 @@
 # Multitask DiT Policy
 
+## Training throughput
+
+On CUDA, pass `--policy.compile_model=true`. The training step is dominated by the CLIP ViT-B/16
+forward and backward, and `torch.compile` fuses the elementwise work around its GEMMs. Measured on one
+A100 80GB in bf16 at an effective batch of 320: +22% to +31% samples/s and about 22% less peak memory
+across LIBERO (256x256 images), RoboCasa (256x256 video, 3 cameras) and a 480x640 real-robot dataset.
+It costs a one-off compile (~90s) at the first step and once per new batch shape.
+
 ## Citation
 
 If you use this work, please cite the following works:

--- a/src/lerobot/policies/multi_task_dit/configuration_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/configuration_multi_task_dit.py
@@ -76,6 +76,16 @@ class MultiTaskDiTConfig(PreTrainedConfig):
     image_crop_shape: tuple[int, int] | None = (224, 224)  # Crop shape (CLIP default)
     image_crop_is_random: bool = True  # Random crop during training, center at inference
 
+    # Compile the vision tower and the noise predictor with torch.compile. Fuses the
+    # elementwise work (GELU, residual adds, layer norm, autocast casts) that otherwise
+    # dominates the ViT-B/16 forward/backward in eager mode. Costs a one-off compile
+    # (~90s on an A100 at batch 160) at the first step and once per new batch shape: the
+    # dataloader's partial last batch of an epoch, and the inference batch.
+    compile_model: bool = False
+    # torch.compile mode; None is inductor's default. "max-autotune-no-cudagraphs" measured no
+    # throughput gain on an A100 for four times the compile time.
+    compile_mode: str | None = None
+
     # Text Encoder (CLIP)
     text_encoder_name: str = "openai/clip-vit-base-patch16"  # HuggingFace CLIP model
     tokenizer_max_length: int = 77  # Max length for tokenized text (CLIP default is 77)

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -39,6 +39,7 @@ from torch import Tensor
 from lerobot.utils.import_utils import _diffusers_available, _transformers_available, require_package
 
 from .configuration_multi_task_dit import MultiTaskDiTConfig
+from .processor_multi_task_dit import OBS_LANGUAGE_ROW_INDEX
 
 # Conditional import for type checking and lazy loading
 if TYPE_CHECKING or _transformers_available:
@@ -204,16 +205,26 @@ class MultiTaskDiTPolicy(PreTrainedPolicy):
 class CLIPVisionEncoder(nn.Module):
     """CLIP vision encoder using the CLS token for global image representation."""
 
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str, compile_model: bool = False, compile_mode: str | None = None):
         super().__init__()
         self.model_name = model_name
         self.model = CLIPVisionModel.from_pretrained(self.model_name)
         self.num_non_spatial_tokens = 1
         self.embed_dim = self.model.config.hidden_size
+        # The compiled callable wraps the bound forward rather than replacing the module, so
+        # parameters, state_dict keys and .to() are untouched.
+        # dynamic=False: a second batch shape (the dataloader's partial last batch, or inference)
+        # compiles its own static graph once instead of moving every shape to slower
+        # dynamic-shape kernels.
+        self._model_forward = (
+            torch.compile(self.model.forward, dynamic=False, mode=compile_mode)
+            if compile_model
+            else self.model.forward
+        )
 
     def forward(self, x: Tensor) -> Tensor:
         """Encode RGB image to CLS token."""
-        outputs = self.model(pixel_values=x, output_hidden_states=False)
+        outputs = self._model_forward(pixel_values=x, output_hidden_states=False)
         cls_token = outputs.last_hidden_state[:, 0]
         b, embed_dim = cls_token.shape
         return cls_token.reshape(b, embed_dim, 1, 1)
@@ -269,11 +280,18 @@ class ObservationEncoder(nn.Module):
 
             if config.use_separate_rgb_encoder_per_camera:
                 self.vision_encoders = nn.ModuleList(
-                    [CLIPVisionEncoder(model_name=config.vision_encoder_name) for _ in self.camera_names]
+                    [
+                        CLIPVisionEncoder(
+                            config.vision_encoder_name, config.compile_model, config.compile_mode
+                        )
+                        for _ in self.camera_names
+                    ]
                 )
                 self.vision_encoder = None
             else:
-                self.vision_encoder = CLIPVisionEncoder(model_name=config.vision_encoder_name)
+                self.vision_encoder = CLIPVisionEncoder(
+                    config.vision_encoder_name, config.compile_model, config.compile_mode
+                )
                 self.vision_encoders = None
         else:
             self.vision_encoder = None
@@ -375,6 +393,10 @@ class ObservationEncoder(nn.Module):
             attention_mask = batch[OBS_LANGUAGE_ATTENTION_MASK]  # [batch_size, seq_length]
 
             text_features = self.text_encoder(input_ids, attention_mask)
+            # The processor tokenizes distinct task strings only; map them back to samples.
+            row_index = batch.get(OBS_LANGUAGE_ROW_INDEX)
+            if row_index is not None:
+                text_features = text_features[row_index]
 
             text_features = text_features.unsqueeze(1).expand(-1, n_obs_steps, -1)
             conditioning_feats.append(text_features)
@@ -606,6 +628,11 @@ class DiffusionTransformer(nn.Module):
 
         self.output_proj = nn.Linear(self.hidden_size, self.action_dim)
         self._initialize_weights()
+        self._blocks_forward = (
+            torch.compile(self._run_blocks, dynamic=False, mode=config.compile_mode)
+            if config.compile_model
+            else self._run_blocks
+        )
 
     def _initialize_weights(self):
         for block in self.transformer_blocks:
@@ -623,10 +650,12 @@ class DiffusionTransformer(nn.Module):
         if self.pos_embedding is not None:
             hidden_seq = hidden_seq + self.pos_embedding[:, :seq_len, :]
 
+        return self.output_proj(self._blocks_forward(hidden_seq, cond_features))
+
+    def _run_blocks(self, hidden_seq: Tensor, cond_features: Tensor) -> Tensor:
         for block in self.transformer_blocks:
             hidden_seq = block(hidden_seq, cond_features)
-
-        return self.output_proj(hidden_seq)
+        return hidden_seq
 
 
 # -- Objectives --

--- a/src/lerobot/policies/multi_task_dit/processor_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/processor_multi_task_dit.py
@@ -14,19 +14,81 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from typing import Any
 
 import torch
+from torch import Tensor
 
 from lerobot.processor import (
     PolicyAction,
     PolicyProcessorPipeline,
+    ProcessorStepRegistry,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
 )
+from lerobot.processor.pipeline import RobotObservation
+from lerobot.utils.constants import OBS_LANGUAGE, OBS_LANGUAGE_ATTENTION_MASK, OBS_LANGUAGE_TOKENS
 
 from .configuration_multi_task_dit import MultiTaskDiTConfig
+
+# Maps each sample in the batch to its row in the de-duplicated token tensors.
+OBS_LANGUAGE_ROW_INDEX = OBS_LANGUAGE + ".row_index"
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="multi_task_dit_task_tokenizer")
+class DedupTaskTokenizerProcessorStep(TokenizerProcessorStep):
+    """Tokenizes each distinct task string once per batch, and only once ever per string.
+
+    A batch of hundreds of samples carries a handful of distinct task strings, and the frozen
+    CLIP text tower is a pure function of the tokens. This step emits tokens for the distinct
+    strings only, plus `observation.language.row_index` mapping every sample to its row, so
+    the policy runs the tower on U rows instead of B and gathers. Tokenization is cached per
+    string, so the Hugging Face tokenizer runs once per task over a whole training run
+    rather than on every batch. Done here, on host strings, rather than with `torch.unique`
+    on the device, which sorts rows and forces a device sync.
+
+    Subtasks are not tokenized; this policy does not consume them.
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+        self._token_cache: dict[str, tuple[Tensor, Tensor]] = {}
+
+    def observation(self, observation: RobotObservation) -> RobotObservation:
+        task = self.get_task(self.transition)
+        if task is None:
+            raise ValueError("Task cannot be None")
+
+        unique = list(dict.fromkeys(task))
+        missing = [t for t in unique if t not in self._token_cache]
+        if missing:
+            tokenized = self._tokenize_text(missing)
+            for i, text in enumerate(missing):
+                self._token_cache[text] = (
+                    tokenized["input_ids"][i],
+                    tokenized["attention_mask"][i].to(dtype=torch.bool),
+                )
+        row_of = {text: i for i, text in enumerate(unique)}
+        tokens = torch.stack([self._token_cache[t][0] for t in unique])
+        mask = torch.stack([self._token_cache[t][1] for t in unique])
+        row_index = torch.tensor([row_of[t] for t in task], dtype=torch.long)
+
+        target_device = self._detect_device(self.transition)
+        if target_device is not None:
+            tokens, mask, row_index = (
+                tokens.to(target_device),
+                mask.to(target_device),
+                row_index.to(target_device),
+            )
+
+        new_observation = dict(observation)
+        new_observation[OBS_LANGUAGE_TOKENS] = tokens
+        new_observation[OBS_LANGUAGE_ATTENTION_MASK] = mask
+        new_observation[OBS_LANGUAGE_ROW_INDEX] = row_index
+        return new_observation
 
 
 def make_multi_task_dit_pre_post_processors(
@@ -42,7 +104,7 @@ def make_multi_task_dit_pre_post_processors(
     The pre-processing pipeline prepares the input data for the model by:
     1. Renaming features.
     2. Adding a batch dimension.
-    3. Tokenizing the language task description (if present).
+    3. Tokenizing the distinct language task descriptions (if present), with a per-sample row index.
     4. Moving the data to the specified device.
     5. Normalizing the input and output features based on dataset statistics.
 
@@ -65,7 +127,7 @@ def make_multi_task_dit_pre_post_processors(
     input_steps = [
         steps.rename_observations,
         steps.add_batch_dim,
-        TokenizerProcessorStep(
+        DedupTaskTokenizerProcessorStep(
             tokenizer_name=config.text_encoder_name,
             padding=config.tokenizer_padding,
             padding_side=config.tokenizer_padding_side,


### PR DESCRIPTION
## Summary / Motivation

The `multi_task_dit` training step is dominated by the CLIP vision encoder forward and backward, with ~40% of eager GPU time in unfused kernels. This adds the opt-in `compile_model` / `compile_mode` knobs the other policies expose, and dedups task strings in the policy's processor so the tokenizer and text encoder run once per distinct task instead of once per data row. The training throughput was significantly improved by this, but it actually makes the relative GPU utilization go down because the GPU time is more efficient, so this isexpected.

There are some additional items that could reduce spiky drops in GPU utilization, but those appear to be related to the overall training infra and not multitask DiT policy specific, so they are left to future work.

One A100 80GB, bf16, effective batch 320, steady state:

| dataset | before | after | peak mem |
|---|---|---|---|
| LIBERO (256x256 images, 2 cams) | 206 sample/s | 253 (+23%) | 62 → 48 GB |
| svla_so101_pickplace (480×640 Video) | 176 sample/s | 215 (+22%) | 67 → 53 GB |
| RoboCasa CloseFridge (256x256 video, 3 viewss) | 147 sample/s | 193 (+31%) | 48 → 38 GB |

cc: @s1lent4gnt 

## What changed

- `compile_model` (default off) and `compile_mode` on the config, named like diffusion / pi0 / smolvla.
- `torch.compile(dynamic=False)` wraps the CLIP vision forward and the DiT block loop as bound methods; parameters and `state_dict` keys are unchanged, so checkpoints are unaffected.
- `DedupTaskTokenizerProcessorStep` replaces the generic tokenizer step: tokenizes each distinct task once (cached), emits tokens/mask for the distinct rows plus `observation.language.row_index`; the encoder gathers back.
- README: "Training throughput" section recommending `--policy.compile_model=true` on CUDA.
- No breaking changes to the interface

## How was this tested (or how to run locally)

- `pytest -q tests/policies -k multi_task_dit` passes.
- Compiled vs eager: identical loss on CPU, matching gradients on every CLIP parameter. Dedup conditioning vs per-row: max abs diff 1e-6.
- A100 runs on the three datasets above (NVML sampling, per-step timing, torch.profiler traces). Reproduce: README LIBERO recipe + `--policy.compile_model=true --batch_size=160 --accelerator.gradient_accumulation.steps=2 --accelerator.mixed_precision=bf16`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3702 

## Reviewer notes

- Compile wraps are a few lines in `modeling_multi_task_dit.py`; the dedup step in `processor_multi_task_dit.py` keeps the tokenizer step's constructor args, so pipeline configs do not change.